### PR TITLE
hot fix installation instruction in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ install this package.
 
 ``` commandline
 library(devtools)
-install_github("robert-koch-institut/Excess_count_detection_for_epidemiological_time_series")
+install_github("robert-koch-institut/excode",subdir = "software")
 ```
 
 ## Overview


### PR DESCRIPTION
The installation path used in devtools::install_github() was still set to the previous repo without using subdir as well.