### PR TITLE
Fix github page action (hopefully)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,6 +16,10 @@ jobs:
   pkgdown:
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
+    defaults:
+      run:
+        working-directory: software
+        # specification that the job is run inside the software folder where the excode package lives
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
@@ -33,6 +37,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          working-directory: software
           extra-packages: any::pkgdown, local::.
           needs: website
 
@@ -46,4 +51,4 @@ jobs:
         with:
           clean: false
           branch: gh-pages
-          folder: docs
+          folder: software/docs

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,7 @@
 
 
 Documentation  
+
 # excode: Excess Count Detection in Epidemiological Time Series
 
 <br> 
@@ -57,7 +58,7 @@ surveillance.
 This is an R package. You can use `install_github()` from devtools to
 install this package.
 
-``` commandline
+```r
 library(devtools)
 install_github("robert-koch-institut/excode",subdir = "software")
 ```
@@ -103,7 +104,7 @@ The following code example illustrates how to fit a three-state model with
 sine/cosine functions ('Harmonic') to model seasonal and a natural cubic 
 spline with two knots to caputre long-term trends ('Spline2').
 
-``` commandline
+```r
 library(excode)
 data(mort_df_germany)
 sum_har_nb <- run_excode(surv_ts = mort_df_germany,
@@ -118,7 +119,7 @@ sum_har_nb <- run_excode(surv_ts = mort_df_germany,
 Results can be extracted using the `summary()` and plotted with the 
 `plot_excode_summary()` functions:
 
-``` commandline
+```r
 sum_har_nb <- summary(res_har_nb)
 plot_excode_summary(sum_har_nb)
 ```


### PR DESCRIPTION
- moved the pkgdown.yaml under software/.github/workflows to the highest level together with the other actions
- adapted the yaml so that it goes into the subfolder software to find the package and build the github page

Side note: 
Another small reason why the software sub folder can be a bit annyoing because it took some time to then actually adapt the github action with the subfolder.

We will see if this works as soon as this is integrated in main as the action runs only with push on main